### PR TITLE
fix: stop reacting on chmod

### DIFF
--- a/envi.go
+++ b/envi.go
@@ -471,7 +471,7 @@ func (envi *Envi) fileWatcher(
 				continue
 			}
 
-			if event.Has(fsnotify.Chmod) || event.Has(fsnotify.Write) {
+			if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
 				err := loadFunc()
 				if err != nil {
 					watchErrChan <- fmt.Errorf("error reloading watched file: %w", err)


### PR DESCRIPTION
- Prevents the filewatcher from reacting to CHMOD operations which is not necessary on linux but causes problems on macOS
- Lets the filewatcher react to CREATE operations instead