### PR TITLE
fix: don't require tags on unexported fields

### DIFF
--- a/envi.go
+++ b/envi.go
@@ -156,6 +156,12 @@ func (e *Envi) loadConfig(config any) error {
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
+
+		// filter out unexported fields (CanSet() is fales for unexported fields)
+		if !field.CanSet() {
+			continue
+		}
+
 		field = resolveValuePointer(field)
 
 		defaultTag := getStructTag(t.Field(i), tagDefault)

--- a/envi.go
+++ b/envi.go
@@ -157,7 +157,7 @@ func (e *Envi) loadConfig(config any) error {
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
 
-		// filter out unexported fields (CanSet() is fales for unexported fields)
+		// filter out unexported fields (CanSet() is false for unexported fields)
 		if !field.CanSet() {
 			continue
 		}


### PR DESCRIPTION
Until now, envi would require unexported fields of the config struct to either have a `default` or `env` tag. This PR fixes that.